### PR TITLE
Fixing focus

### DIFF
--- a/ChatNotifications.js
+++ b/ChatNotifications.js
@@ -206,11 +206,13 @@
     
     function createPing(data) {
         if (data.config.notifications) {
-            var notification = new Notification(data.user, {
-                body: data.message,
-                icon: data.avatar
-            });
-            setTimeout(function() { notification.close() }, 5000);
+            if (!document.hasFocus()) {
+                var notification = new Notification(data.user, {
+                    body: data.message,
+                    icon: data.avatar
+                });
+                setTimeout(function() { notification.close() }, 5000);
+            }
         }
         
         if (data.config.audio) {


### PR DESCRIPTION
Notification will now no longer appear if the user is currently focused on the chat window.
